### PR TITLE
fix(android): prevent Settings modal from clipping and trapping the user

### DIFF
--- a/src/components/dashboard/SettingsModal.tsx
+++ b/src/components/dashboard/SettingsModal.tsx
@@ -648,7 +648,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-center justify-center p-4 overflow-y-auto mobile-safe-container">
+    <div className="fixed inset-0 z-[60] flex items-start md:items-center justify-center p-4 overflow-y-auto mobile-safe-container">
       {/* Backdrop */}
       <div
         className="absolute inset-0 bg-black/60 backdrop-blur-sm"
@@ -656,7 +656,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
       />
 
       {/* Modal - use grid to handle overflow properly */}
-      <div className="relative bg-drone-secondary rounded-xl border border-gray-700 shadow-2xl w-full max-w-[845px] max-h-[calc(100vh-2rem)] modal-mobile-max grid grid-rows-[auto_1fr]">
+      <div className="relative bg-drone-secondary rounded-xl border border-gray-700 shadow-2xl w-full max-w-[845px] modal-mobile-max grid grid-rows-[auto_1fr]">
         {/* Blocking overlay while a long-running operation is in progress */}
         {isBusy && (
           <div className="absolute inset-0 z-10 flex flex-col items-center justify-center bg-white/90 dark:bg-black/60 backdrop-blur-[2px] rounded-xl">

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,13 @@ import './index.css';
 import './styles/mobile.css';
 import './i18n';
 
+// Expose actual visible-area height as --vh so CSS can use it reliably.
+// window.innerHeight is correct on all WebViews (incl. old Android) unlike dvh.
+const updateVhVar = () =>
+  document.documentElement.style.setProperty('--vh', `${window.innerHeight * 0.01}px`);
+updateVhVar();
+window.addEventListener('resize', updateVhVar);
+
 // Attach Tauri console logger only in Tauri mode
 if (!isWebMode()) {
   import('@tauri-apps/plugin-log')

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -21,5 +21,6 @@
 }
 
 .modal-mobile-max {
-  max-height: min(85vh, calc(100dvh - var(--mobile-safe-top) - var(--mobile-safe-bottom) - 1.5rem));
+  /* --vh is set via JS (window.innerHeight) and works on all WebViews including old Android */
+  max-height: calc(var(--vh, 1vh) * 100 - var(--mobile-safe-top) - var(--mobile-safe-bottom) - 2rem);
 }


### PR DESCRIPTION
Fixes #190

## Summary
On Android (DJI RC Pro 2, landscape), the Settings screen rendered with overlapping/clipped controls and the close button below the visible area, leaving the user unable to dismiss it without restarting the app.

## Changes
- Make the Settings container scrollable so content past the viewport is reachable.
- Respect safe-area / system insets so the bottom of the modal is not hidden behind the navigation bar.
- <если меняли конкретный компонент/CSS — назовите файл>

## Testing
- DJI RC Pro 2 (landscape, ~1920×1080-ish): all controls reachable, close button visible, modal dismissable.
- Phone-size Android viewport (emulator): no regression.
- Desktop: no visual regression.

## Notes
Minimal, focused change as per CONTRIBUTING.